### PR TITLE
Implement account pages and global header

### DIFF
--- a/src/timber/auth.py
+++ b/src/timber/auth.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from flask import Blueprint, flash, redirect, render_template, request, url_for
-from flask_login import login_required, login_user, logout_user
+from flask_login import current_user, login_required, login_user, logout_user
+
+from .extensions import db
 
 from .models import User
 
@@ -15,16 +17,21 @@ def register():
 
 @auth_bp.post("/register")
 def register_post():
+    name = request.form.get("name", "").strip()
     email = request.form.get("email", "").lower()
     password = request.form.get("password", "")
-    if not email or not password:
-        flash("Email and password required", "danger")
+    confirm = request.form.get("confirm_password", "")
+    if not name or not email or not password:
+        flash("All fields required", "danger")
+        return redirect(url_for("auth.register"))
+    if password != confirm:
+        flash("Passwords do not match", "danger")
         return redirect(url_for("auth.register"))
     if User.query.filter_by(email=email).first():
         flash("Email already registered", "danger")
         return redirect(url_for("auth.register"))
     try:
-        user = User.create(email, password)
+        user = User.create(email, name, password)
     except ValueError:
         flash("Email already registered", "danger")
         return redirect(url_for("auth.register"))
@@ -57,3 +64,46 @@ def logout():
     logout_user()
     flash("Logged out", "success")
     return redirect(url_for("index"))
+
+
+@auth_bp.get("/account")
+@login_required
+def account():
+    return render_template("account.html")
+
+
+@auth_bp.post("/account")
+@login_required
+def account_post():
+    name = request.form.get("name", "").strip()
+    if not name:
+        flash("Name required", "danger")
+        return redirect(url_for("auth.account"))
+    current_user.name = name
+    db.session.commit()
+    flash("Account updated", "success")
+    return redirect(url_for("auth.account"))
+
+
+@auth_bp.get("/password")
+@login_required
+def password():
+    return render_template("password.html")
+
+
+@auth_bp.post("/password")
+@login_required
+def password_post():
+    old = request.form.get("old_password", "")
+    new = request.form.get("new_password", "")
+    confirm = request.form.get("confirm_password", "")
+    if new != confirm:
+        flash("Passwords do not match", "danger")
+        return redirect(url_for("auth.password"))
+    if not current_user.check_password(old):
+        flash("Current password incorrect", "danger")
+        return redirect(url_for("auth.password"))
+    current_user.set_password(new)
+    db.session.commit()
+    flash("Password updated", "success")
+    return redirect(url_for("auth.account"))

--- a/src/timber/models.py
+++ b/src/timber/models.py
@@ -12,13 +12,14 @@ class User(db.Model, UserMixin):  # type: ignore
     __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), nullable=False)
     email = db.Column(db.String(255), unique=True, nullable=False, index=True)
     password_hash = db.Column(db.String(128), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     @classmethod
-    def create(cls, email: str, password: str) -> "User":
-        user = cls(email=email)
+    def create(cls, email: str, name: str, password: str) -> "User":
+        user = cls(email=email, name=name)
         user.set_password(password)
         db.session.add(user)
         try:

--- a/src/timber/templates/account.html
+++ b/src/timber/templates/account.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}My Account{% endblock %}
+{% block content %}
+<div class="container mt-5" style="max-width: 500px;">
+  <h1 class="mb-4">My Account</h1>
+  <form method="post">
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" class="form-control" id="name" name="name" value="{{ current_user.name }}" required>
+    </div>
+    <div class="mb-3">
+      <label for="email" class="form-label">Email</label>
+      <input type="email" class="form-control" id="email" value="{{ current_user.email }}" disabled>
+    </div>
+    <div class="mb-3">
+      <a href="{{ url_for('auth.password') }}">Update password</a>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </form>
+</div>
+{% endblock %}

--- a/src/timber/templates/base.html
+++ b/src/timber/templates/base.html
@@ -4,9 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <title>{% block title %}Timber{% endblock %}</title>
   </head>
   <body>
+    {% include 'header.html' %}
     {% block content %}{% endblock %}
 
     <div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 1100">

--- a/src/timber/templates/header.html
+++ b/src/timber/templates/header.html
@@ -1,0 +1,26 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Timber</a>
+    <div class="d-flex ms-auto">
+      {% if current_user.is_authenticated %}
+      <div class="dropdown">
+        <a class="btn btn-link dropdown-toggle" href="#" id="accountMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="bi bi-person-fill"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="accountMenu">
+          <li><a class="dropdown-item" href="{{ url_for('auth.account') }}">My Account</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li>
+            <form action="{{ url_for('auth.logout') }}" method="get" class="px-3">
+              <button type="submit" class="btn btn-outline-danger w-100">Log Out</button>
+            </form>
+          </li>
+        </ul>
+      </div>
+      {% else %}
+      <a href="{{ url_for('auth.register') }}" class="btn btn-primary me-2">Sign Up</a>
+      <a href="{{ url_for('auth.login') }}" class="nav-link">Log In</a>
+      {% endif %}
+    </div>
+  </div>
+</nav>

--- a/src/timber/templates/index.html
+++ b/src/timber/templates/index.html
@@ -1,13 +1,20 @@
 {% extends 'base.html' %}
 {% block title %}Home{% endblock %}
 {% block content %}
-<div class="container mt-5">
-  <h1>Welcome to Timber</h1>
+<div class="container-fluid mt-4">
   {% if current_user.is_authenticated %}
-    <p class="lead">Logged in as {{ current_user.email }}.</p>
-    <a href="{{ url_for('auth.logout') }}" class="btn btn-secondary">Logout</a>
+  <div class="row">
+    <div class="col-md-3" id="properties-pane">
+      <h2>Properties</h2>
+    </div>
+    <div class="col-md-9" id="canvas-pane">
+      <h2>Canvas</h2>
+    </div>
+  </div>
   {% else %}
-    <p class="lead">Please <a href="{{ url_for('auth.login') }}">log in</a> or <a href="{{ url_for('auth.register') }}">register</a>.</p>
+  <div class="text-center">
+    <p class="lead">Please <a href="{{ url_for('auth.login') }}">log in</a> or <a href="{{ url_for('auth.register') }}">sign up</a> to continue.</p>
+  </div>
   {% endif %}
 </div>
 {% endblock %}

--- a/src/timber/templates/password.html
+++ b/src/timber/templates/password.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}Update Password{% endblock %}
+{% block content %}
+<div class="container mt-5" style="max-width: 400px;">
+  <h1 class="mb-4">Update Password</h1>
+  <form method="post">
+    <div class="mb-3">
+      <label for="old_password" class="form-label">Current Password</label>
+      <input type="password" class="form-control" id="old_password" name="old_password" required>
+    </div>
+    <div class="mb-3">
+      <label for="new_password" class="form-label">New Password</label>
+      <input type="password" class="form-control" id="new_password" name="new_password" required>
+    </div>
+    <div class="mb-3">
+      <label for="confirm_password" class="form-label">Confirm New Password</label>
+      <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Update</button>
+  </form>
+</div>
+{% endblock %}

--- a/src/timber/templates/register.html
+++ b/src/timber/templates/register.html
@@ -5,12 +5,20 @@
   <h1 class="mb-4">Sign Up</h1>
   <form method="post">
     <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" class="form-control" id="name" name="name" required>
+    </div>
+    <div class="mb-3">
       <label for="email" class="form-label">Email</label>
       <input type="email" class="form-control" id="email" name="email" required>
     </div>
     <div class="mb-3">
       <label for="password" class="form-label">Password</label>
       <input type="password" class="form-control" id="password" name="password" required>
+    </div>
+    <div class="mb-3">
+      <label for="confirm_password" class="form-label">Confirm Password</label>
+      <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
     </div>
     <button type="submit" class="btn btn-primary">Register</button>
   </form>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,12 @@ def test_user_registration_and_login():
         client = app.test_client()
         client.post(
             "/auth/register",
-            data={"email": "user@example.com", "password": "secret"},
+            data={
+                "name": "User",
+                "email": "user@example.com",
+                "password": "secret",
+                "confirm_password": "secret",
+            },
             follow_redirects=True,
         )
         assert User.query.count() == 1
@@ -46,12 +51,22 @@ def test_duplicate_registration():
         client = app.test_client()
         client.post(
             "/auth/register",
-            data={"email": "dup@example.com", "password": "secret"},
+            data={
+                "name": "Dup",
+                "email": "dup@example.com",
+                "password": "secret",
+                "confirm_password": "secret",
+            },
             follow_redirects=True,
         )
         resp = client.post(
             "/auth/register",
-            data={"email": "dup@example.com", "password": "secret"},
+            data={
+                "name": "Dup",
+                "email": "dup@example.com",
+                "password": "secret",
+                "confirm_password": "secret",
+            },
             follow_redirects=True,
         )
         assert b"Email already registered" in resp.data


### PR DESCRIPTION
## Summary
- add header with login/signup or account dropdown
- add account management and password update pages
- add name field to user model and registration form
- update index with properties/canvas panes
- adjust tests for registration updates

## Testing
- `flake8`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb27610cc8322a5d57312143a0d96