### PR TITLE
Fix plane rendering order

### DIFF
--- a/src/timber/templates/index.html
+++ b/src/timber/templates/index.html
@@ -146,23 +146,23 @@ function planeCorners(el) {
   if (n === 'X') {
     return [
       { x: el.x, y: el.y - l, z: el.z - w },
-      { x: el.x, y: el.y - l, z: el.z + w },
       { x: el.x, y: el.y + l, z: el.z - w },
       { x: el.x, y: el.y + l, z: el.z + w },
+      { x: el.x, y: el.y - l, z: el.z + w },
     ];
   } else if (n === 'Y') {
     return [
       { x: el.x - l, y: el.y, z: el.z - w },
-      { x: el.x - l, y: el.y, z: el.z + w },
       { x: el.x + l, y: el.y, z: el.z - w },
       { x: el.x + l, y: el.y, z: el.z + w },
+      { x: el.x - l, y: el.y, z: el.z + w },
     ];
   }
   return [
     { x: el.x - l, y: el.y - w, z: el.z },
-    { x: el.x - l, y: el.y + w, z: el.z },
     { x: el.x + l, y: el.y - w, z: el.z },
     { x: el.x + l, y: el.y + w, z: el.z },
+    { x: el.x - l, y: el.y + w, z: el.z },
   ];
 }
 


### PR DESCRIPTION
## Summary
- fix polygon vertex ordering for planes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510d2dab8c8322bc9a5e041b93115f