### PR TITLE
Add sheet renaming with title display

### DIFF
--- a/src/timber/templates/index.html
+++ b/src/timber/templates/index.html
@@ -19,6 +19,10 @@
       </ul>
     </div>
     <div class="col-md-7" id="canvas-pane">
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h2 class="mb-0" id="sheet-title"></h2>
+        <i id="edit-title" class="bi bi-pencil-square" role="button"></i>
+      </div>
       <svg id="canvas" style="border:1px solid #ccc; width:100%; height:400px;"></svg>
       <div class="mt-2" id="canvas-tools">
         <select id="element-type" class="form-select form-select-sm d-inline w-auto me-2">
@@ -59,6 +63,16 @@
 const containerEl = document.querySelector('[data-sheet-id]');
 let sheetId = parseInt(containerEl.dataset.sheetId);
 let sheets = JSON.parse(containerEl.dataset.sheets || '[]');
+const sheetTitleEl = document.getElementById('sheet-title');
+
+function getCurrentSheet() {
+  return sheets.find(s => s.id === sheetId);
+}
+
+function updateSheetHeader() {
+  const s = getCurrentSheet();
+  if (s && sheetTitleEl) sheetTitleEl.textContent = s.name;
+}
 let elements = [];
 let selectedId = null;
 let dragId = null;
@@ -88,6 +102,7 @@ function renderSheetList() {
     li.innerHTML = `<span>${s.name}</span><i class="bi bi-trash-fill delete-sheet" role="button" aria-label="Delete"></i>`;
     list.appendChild(li);
   });
+  updateSheetHeader();
 }
 
 async function createSheet() {
@@ -739,6 +754,10 @@ async function loadState() {
   const resp = await fetch(`/sheet/${sheetId}`);
   if (resp.ok) {
     const data = await resp.json();
+    const s = sheets.find(sh => sh.id === data.id);
+    if (s) {
+      s.name = data.name;
+    }
     elements = (data.elements || []).map(e => {
       const obj = {
         id: e.id,
@@ -769,6 +788,7 @@ async function loadState() {
       }
       return obj;
     });
+    updateSheetHeader();
     render();
   }
 }
@@ -787,6 +807,24 @@ document.getElementById('canvas').addEventListener('wheel', ev => {
   ev.preventDefault();
   zoom *= ev.deltaY < 0 ? 1.1 : 0.9;
   render();
+});
+
+document.getElementById('edit-title').addEventListener('click', async () => {
+  const sheet = getCurrentSheet();
+  if (!sheet) return;
+  const name = prompt('Sheet name', sheet.name);
+  if (name && name.trim() && name !== sheet.name) {
+    const resp = await fetch(`/sheet/${sheet.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      sheet.name = data.name;
+      renderSheetList();
+    }
+  }
 });
 
 document.querySelectorAll('.view-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- show selected sheet title above the canvas
- allow updating sheet names via a new `PUT /sheet/<id>` route
- keep the sheet list and canvas title in sync when renamed
- test renaming behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685115162e0483229ca45cba16bff1fb