### PR TITLE
Fix None loads in solver

### DIFF
--- a/src/timber/engine.py
+++ b/src/timber/engine.py
@@ -97,9 +97,14 @@ def solve(model: Model) -> Results:
     # Assemble global load vector
     for load in model.loads:
         idx = load.joint * 3
-        F_ext[idx] += load.fx
-        F_ext[idx + 1] += load.fy
-        F_ext[idx + 2] += load.mz
+        # Incoming data may contain null values which become ``None`` when
+        # parsed from JSON.  Treat these as zeros so the solver does not crash.
+        fx = 0.0 if load.fx is None else float(load.fx)
+        fy = 0.0 if load.fy is None else float(load.fy)
+        mz = 0.0 if load.mz is None else float(load.mz)
+        F_ext[idx] += fx
+        F_ext[idx + 1] += fy
+        F_ext[idx + 2] += mz
 
     # Assemble global stiffness matrix
     for m in model.members:

--- a/tests/test_null_loads.py
+++ b/tests/test_null_loads.py
@@ -1,0 +1,14 @@
+import sys
+sys.path.append('src')
+from timber import Joint, Member, Load, Support, Model, solve
+
+
+def test_null_load_values():
+    model = Model(
+        joints=[Joint(0.0, 0.0), Joint(1.0, 0.0)],
+        members=[Member(start=0, end=1, E=200e9, A=0.01, I=1e-6)],
+        loads=[Load(joint=1, fx=None, fy=None, mz=None)],
+        supports=[Support(joint=0, ux=True, uy=True, rz=True)],
+    )
+    result = solve(model)
+    assert isinstance(result.displacements[1][1], float)


### PR DESCRIPTION
## Summary
- ensure `solve()` gracefully handles null load values
- add regression test for `None` load components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685239853b808322b3d533bca743c21c