### PR TITLE
Improve solver diagnostics

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,7 +6,7 @@ import sys
 from flask import Flask, jsonify, render_template, request
 from flask_login import current_user, login_required
 
-from timber import Joint, Load, Member, Model, Support, solve
+from timber import Joint, Load, Member, Model, Support, solve_with_diagnostics
 from timber.extensions import bcrypt, db, login_manager, migrate
 
 # -------------------------------------------------------------------
@@ -86,11 +86,12 @@ def create_app(config_object: str | None = None) -> Flask:
         except (TypeError, KeyError) as exc:
             return jsonify({"error": f"Invalid payload: {exc}"}), 400
 
-        res = solve(model)
+        res, issues = solve_with_diagnostics(model)
         return jsonify(
             {
                 "displacements": {str(k): list(v) for k, v in res.displacements.items()},
                 "reactions": {str(k): list(v) for k, v in res.reactions.items()},
+                "issues": issues,
             }
         )
 

--- a/src/timber/__init__.py
+++ b/src/timber/__init__.py
@@ -1,6 +1,6 @@
 """Main timber package exposing calculation engine."""
 
-from .engine import Joint, Load, Member, Model, Results, Support, solve
+from .engine import Joint, Load, Member, Model, Results, Support, solve, solve_with_diagnostics
 from .extensions import db
 from .models import User
 
@@ -12,6 +12,7 @@ __all__ = [
     "Model",
     "Results",
     "solve",
+    "solve_with_diagnostics",
     "User",
     "db",
 ]

--- a/src/timber/templates/index.html
+++ b/src/timber/templates/index.html
@@ -928,7 +928,15 @@ async function solveModel() {
     return;
   }
   const data = await resp.json();
-  const lines = ['Displacements:'];
+  const lines = [];
+  if (data.issues && data.issues.length) {
+    lines.push('Issues:');
+    for (const issue of data.issues) {
+      lines.push(' - ' + issue);
+    }
+    lines.push('');
+  }
+  lines.push('Displacements:');
   for (const [k, v] of Object.entries(data.displacements || {})) {
     lines.push(`Joint ${k}: ux=${(+v[0]).toExponential(3)} m, uy=${(+v[1]).toExponential(3)} m, rz=${(+v[2]).toExponential(3)} rad`);
   }


### PR DESCRIPTION
## Summary
- add `solve_with_diagnostics` and expose via package
- show warnings on the frontend if the solve API detects issues
- return a list of issues from `/solve`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852422208408322b7056f380352a431