### PR TITLE
Fix projectPoint tests by updating current view handling

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -18,7 +18,14 @@ let dragStartX = 0;
 let dragStartY = 0;
 let dragOrig = null;
 let dragMode = 'body';
-let currentView = '+X';
+// Use `var` so `currentView` becomes a property of the global object.
+// This allows tests (which run the file in a VM sandbox) to mutate
+// `currentView` by assigning to `global.currentView`.
+var currentView = '+X';
+
+function setCurrentView(view) {
+  currentView = view;
+}
 let zoom = 1;
 let panX = 0;
 let panY = 0;
@@ -806,7 +813,7 @@ document.getElementById('edit-title').addEventListener('click', async () => {
 
 document.querySelectorAll('.view-btn').forEach(btn => {
   btn.addEventListener('click', () => {
-    currentView = btn.dataset.view;
+    setCurrentView(btn.dataset.view);
     document.querySelectorAll('.view-btn').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     render();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -15,6 +15,9 @@ const {
   axisInfo,
   nearestPointOnLine,
 
+  /* view helpers */
+  setCurrentView,
+
   /* sheets / UI */
   getCurrentSheet,
   updateSheetHeader,
@@ -38,12 +41,12 @@ describe('geometry helpers (pure maths)', () => {
     ['+Y', { x: 1, y: 2, z: 3 }, { x: 1, y: -3 }],
     ['-Z', { x: 1, y: 2, z: 3 }, { x: -1, y: -2 }]
   ])('projectPoint for %s view', (view, p, expected) => {
-    global.currentView = view;
+    setCurrentView(view);
     expect(projectPoint(p)).toEqual(expected);
   });
 
   test('unprojectDelta mirrors projectPoint along +X view', () => {
-    global.currentView = '+X';
+    setCurrentView('+X');
     const res = unprojectDelta(5, 0); // dx ⇒ +y , dy ⇒ -z
     expect(res.y).toBeCloseTo(5);
     expect(res.z).toBeCloseTo(0);


### PR DESCRIPTION
## Summary
- expose `setCurrentView` helper in `src/static/index.js`
- update event listeners to use `setCurrentView`
- adjust tests to use the new helper

## Testing
- `npm test -- --ci --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685267b0af648322b1edf81338037de4