### PR TITLE
Add zoom controls and keyboard delete

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -38,6 +38,23 @@ let panStartX = 0;
 let panStartY = 0;
 let panOrigX = 0;
 let panOrigY = 0;
+
+function zoomIn() {
+  zoom *= 1.1;
+  render();
+}
+
+function zoomOut() {
+  zoom *= 0.9;
+  render();
+}
+
+function resetPanZoom() {
+  zoom = 1;
+  panX = 0;
+  panY = 0;
+  render();
+}
 const globalProps = { g: 9.81, units: "metric" };
 const PROP_LABELS = {
   E: "Young's Modulus",
@@ -965,10 +982,13 @@ document.getElementById("canvas").addEventListener("click", () => {
   render();
 });
 document.getElementById("canvas").addEventListener("mousedown", startPan);
-document.getElementById("canvas").addEventListener("wheel", (ev) => {
-  ev.preventDefault();
-  zoom *= ev.deltaY < 0 ? 1.1 : 0.9;
-  render();
+document.getElementById("zoom-in").addEventListener("click", zoomIn);
+document.getElementById("zoom-out").addEventListener("click", zoomOut);
+document.getElementById("home-btn").addEventListener("click", resetPanZoom);
+document.addEventListener("keydown", (ev) => {
+  if (ev.key === "Delete") {
+    deleteElement();
+  }
 });
 
 document.getElementById("edit-title").addEventListener("click", async () => {

--- a/src/timber/templates/index.html
+++ b/src/timber/templates/index.html
@@ -43,6 +43,11 @@
           <button type="button" class="btn btn-outline-secondary view-btn" data-view="+Z">+Z</button>
           <button type="button" class="btn btn-outline-secondary view-btn" data-view="-Z">-Z</button>
         </div>
+        <div class="btn-group btn-group-sm ms-2" role="group" aria-label="Zoom">
+          <button type="button" id="zoom-in" class="btn btn-outline-secondary">+</button>
+          <button type="button" id="zoom-out" class="btn btn-outline-secondary">-</button>
+          <button type="button" id="home-btn" class="btn btn-outline-secondary"><i class="bi bi-house"></i></button>
+        </div>
         <span class="ms-2">View: <span id="current-view">+X</span></span>
       </div>
     </div>

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -369,3 +369,42 @@ describe("addNumberInput widget", () => {
     expect(obj.foo).toBe(123);
   });
 });
+
+//--------------------------------------------------------------------
+//  ZOOM / KEYBOARD CONTROLS
+//--------------------------------------------------------------------
+
+describe("zoom and keyboard controls", () => {
+  test("zoomIn increases projected distance", () => {
+    resetPanZoom();
+    const before = screenCoords({ x: 0, y: 10, z: 0 }).x;
+    zoomIn();
+    const after = screenCoords({ x: 0, y: 10, z: 0 }).x;
+    expect(after - 400).toBeCloseTo((before - 400) * 1.1);
+  });
+
+  test("zoomOut decreases projected distance", () => {
+    resetPanZoom();
+    const before = screenCoords({ x: 0, y: 10, z: 0 }).x;
+    zoomOut();
+    const after = screenCoords({ x: 0, y: 10, z: 0 }).x;
+    expect(after - 400).toBeCloseTo((before - 400) * 0.9);
+  });
+
+  test("resetPanZoom restores default zoom", () => {
+    zoomIn();
+    resetPanZoom();
+    const sc = screenCoords({ x: 0, y: 10, z: 0 }).x;
+    expect(sc).toBeCloseTo(410);
+  });
+
+  test("pressing Delete triggers deleteElement", () => {
+    addElement("Joint");
+    const g = document.querySelector("#canvas g");
+    g.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: 0, clientY: 0, bubbles: true }),
+    );
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete" }));
+    expect(buildModel().joints.length).toBe(0);
+  });
+});

--- a/tests/setupJest.cjs
+++ b/tests/setupJest.cjs
@@ -22,6 +22,11 @@ document.body.innerHTML = `
     <button class="view-btn" data-view="+X"></button>
     <button class="view-btn" data-view="-X"></button>
   </div>
+  <div class="btn-group">
+    <button id="zoom-in"></button>
+    <button id="zoom-out"></button>
+    <button id="home-btn"></button>
+  </div>
   <span id="current-view">+X</span>
   <svg    id="canvas"></svg>
   <select id="element-type"></select>


### PR DESCRIPTION
## Summary
- remove scrollwheel zoom and add discrete zoom buttons
- allow delete key to remove selected element
- add a home button to reset pan and zoom
- test new zoom helpers and keyboard deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685398a3ddd88322ad36045c2785c0fa