### PR TITLE
Fix load amount persistence

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -432,6 +432,16 @@ function addNumberInput(container, label, prop, el) {
   input.addEventListener("input", (ev) => {
     const v = parseFloat(ev.target.value);
     el[prop] = Number.isFinite(v) ? v : 0;
+    if (prop === "amount" && el.type === "Load") {
+      const dx = (el.x2 ?? el.x) - el.x;
+      const dy = (el.y2 ?? el.y) - el.y;
+      const dz = (el.z2 ?? el.z) - el.z;
+      const len = Math.hypot(dx, dy, dz) || 1;
+      const scale = el.amount / len;
+      el.x2 = el.x + dx * scale;
+      el.y2 = el.y + dy * scale;
+      el.z2 = el.z + dz * scale;
+    }
     render(false);
     saveState();
   });

--- a/src/timber/engine.py
+++ b/src/timber/engine.py
@@ -32,6 +32,7 @@ class Load:
     fx: float = 0.0
     fy: float = 0.0
     mz: float = 0.0
+    amount: float = 0.0
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- store `amount` on `Load` dataclass
- keep amount while editing by scaling end coordinates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853a3bcee588322b2f405804933526e