### PR TITLE
Fix load amount not sent to solver

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -1089,7 +1089,13 @@ function buildModel() {
       const dy = (e.y2 ?? e.y) - e.y;
       const len = Math.hypot(dx, dy) || 1;
       const amt = e.amount ?? 0;
-      return { joint: i, fx: (amt * dx) / len, fy: (amt * dy) / len, mz: 0 };
+      return {
+        joint: i,
+        fx: (amt * dx) / len,
+        fy: (amt * dy) / len,
+        mz: 0,
+        amount: amt,
+      };
     });
 
   const supports = elements


### PR DESCRIPTION
## Summary
- send load amount along with fx/fy when building model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ad9b6fe88322b1362333eddec2f0